### PR TITLE
Fix dark mode, login and random activity swappings and crashes

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -135,6 +135,8 @@ dependencies {
     implementation 'de.hdodenhof:circleimageview:3.1.0'
 
     implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0'
+
+    implementation "androidx.fragment:fragment-ktx:1.5.7"
 }
 
 tasks.withType(Test) {

--- a/app/src/androidTest/java/com/github/ybecker/epforuml/ForumAdapterTest.kt
+++ b/app/src/androidTest/java/com/github/ybecker/epforuml/ForumAdapterTest.kt
@@ -79,7 +79,7 @@ class ForumAdapterTest {
 
     @Test
     fun scrollToRefreshQuestionsTest() {
-        scenario.onActivity { MockAuthenticator(it).signIn() }
+        scenario.onActivity { MockAuthenticator(it).signIn().join() }
 
         onView(withId(R.id.swipe_refresh_layout)).perform(swipeDown())
 

--- a/app/src/androidTest/java/com/github/ybecker/epforuml/Notifications/RemoteNotificationServiceTest.kt
+++ b/app/src/androidTest/java/com/github/ybecker/epforuml/Notifications/RemoteNotificationServiceTest.kt
@@ -35,7 +35,8 @@ class RemoteNotificationServiceTest {
     @Test
     fun onMessageReceiveTestLaunchANotification(){
         val scenario = ActivityScenario.launch(MainActivity::class.java)
-        scenario.onActivity { MockAuthenticator(it).signIn() }
+        // TODO: use mock database ?
+        scenario.onActivity { MockAuthenticator(it).signIn() } // TODO: if use mock db then signIn().join() (just in case)
 
         val context = ApplicationProvider.getApplicationContext<Context>()
         val notificationsListener = TestNotificationListener()

--- a/app/src/androidTest/java/com/github/ybecker/epforuml/QuestionDetailsTest.kt
+++ b/app/src/androidTest/java/com/github/ybecker/epforuml/QuestionDetailsTest.kt
@@ -94,7 +94,7 @@ class QuestionDetailsTest {
     @Test
     fun loggedInCanPost() {
         // authentication
-        scenario.onActivity { MockAuthenticator(it).signIn() }
+        scenario.onActivity { MockAuthenticator(it).signIn().join() }
 
 
         // go to last question
@@ -108,7 +108,7 @@ class QuestionDetailsTest {
     @Test
     fun cannotPostEmptyAnswer() {
         // authentication
-        scenario.onActivity { MockAuthenticator(it).signIn() }
+        scenario.onActivity { MockAuthenticator(it).signIn().join() }
 
 
         // go to last question
@@ -127,7 +127,7 @@ class QuestionDetailsTest {
     @Test
     fun writeAnswerAndPostIsDisplayed() {
         // authentication
-        scenario.onActivity { MockAuthenticator(it).signIn() }
+        scenario.onActivity { MockAuthenticator(it).signIn().join() }
 
         // go to last question
         onView(withId(R.id.recycler_forum))
@@ -156,8 +156,8 @@ class QuestionDetailsTest {
 
     @Test
     fun guestUserCannotPostAnswers() {
-        scenario.onActivity { MockAuthenticator(it).signIn() }
-        scenario.onActivity { MockAuthenticator(it).signOut() }
+        scenario.onActivity { MockAuthenticator(it).signIn().join() }
+        scenario.onActivity { MockAuthenticator(it).signOut().join() }
 
         // go to second question
         onView(withId(R.id.recycler_forum))
@@ -170,7 +170,7 @@ class QuestionDetailsTest {
 
     @Test
     fun questionEndorseButtonModifyTheCounter() {
-        scenario.onActivity { MockAuthenticator(it).signIn() }
+        scenario.onActivity { MockAuthenticator(it).signIn().join() }
 
         // go to second question
         onView(withId(R.id.recycler_forum))
@@ -187,7 +187,7 @@ class QuestionDetailsTest {
 
     @Test
     fun questionEndorsementStaysWhenQuitting() {
-        scenario.onActivity { MockAuthenticator(it).signIn() }
+        scenario.onActivity { MockAuthenticator(it).signIn().join() }
 
         // go to second question
         onView(withId(R.id.recycler_forum))
@@ -204,7 +204,7 @@ class QuestionDetailsTest {
 
     @Test
     fun removeQuestionEndorsementTest(){
-        scenario.onActivity { MockAuthenticator(it).signIn() }
+        scenario.onActivity { MockAuthenticator(it).signIn().join() }
 
         onView(withId(R.id.recycler_forum))
             .perform(RecyclerViewActions.actionOnItemAtPosition<RecyclerView.ViewHolder>(1, click()))
@@ -220,7 +220,7 @@ class QuestionDetailsTest {
 
     @Test
     fun answerLikeButtonModifyTheCounter() {
-        scenario.onActivity { MockAuthenticator(it).signIn() }
+        scenario.onActivity { MockAuthenticator(it).signIn().join() }
 
         // go to third question
         onView(withText("About ci")).perform(click())
@@ -235,7 +235,7 @@ class QuestionDetailsTest {
 
     @Test
     fun answerLikeStaysWhenQuitting() {
-        scenario.onActivity { MockAuthenticator(it).signIn() }
+        scenario.onActivity { MockAuthenticator(it).signIn().join() }
 
         // go to third question
         onView(withText("About ci")).perform(click())
@@ -252,7 +252,7 @@ class QuestionDetailsTest {
 
     @Test
     fun removeAnswerLike() {
-        scenario.onActivity { MockAuthenticator(it).signIn() }
+        scenario.onActivity { MockAuthenticator(it).signIn().join() }
 
         // go to third question
         onView(withText("About ci")).perform(click())
@@ -270,7 +270,7 @@ class QuestionDetailsTest {
 
     @Test
     fun scrollToRefreshAnswers() {
-        scenario.onActivity { MockAuthenticator(it).signIn() }
+        scenario.onActivity { MockAuthenticator(it).signIn().join() }
 
         val testQuStr = "NEWQUESTIONTEST"
         var questionId: String? = null

--- a/app/src/androidTest/java/com/github/ybecker/epforuml/account/AccountFragmentsTest.kt
+++ b/app/src/androidTest/java/com/github/ybecker/epforuml/account/AccountFragmentsTest.kt
@@ -61,7 +61,7 @@ class AccountFragmentsTest {
     @Test
     fun checkAccountFragmentLayout() {
         DatabaseManager.useMockDatabase()
-        scenario.onActivity { MockAuthenticator(it).signIn() }
+        scenario.onActivity { MockAuthenticator(it).signIn().join() }
 
         onView(ViewMatchers.withContentDescription(R.string.open))
             .perform(click())
@@ -79,7 +79,7 @@ class AccountFragmentsTest {
     @Test
     fun checkSignOutRemovesCurrentUserAndGoesToGuestFragment() {
         DatabaseManager.useMockDatabase()
-        scenario.onActivity { MockAuthenticator(it).signIn() }
+        scenario.onActivity { MockAuthenticator(it).signIn().join() }
         assertTrue(DatabaseManager.user != null)
 
         Intents.intended(IntentMatchers.hasComponent(MainActivity::class.java.name))
@@ -91,14 +91,14 @@ class AccountFragmentsTest {
         onView(ViewMatchers.withId(R.id.signOutButton))
             .perform(click())
 
-        //assertTrue(DatabaseManager.user == null)
+        assertTrue(DatabaseManager.user == null)
         checkGuest()
     }
 
     @Test
     fun checkDeleteAccountDeletesUserAndGoesToGuestFragment() {
         DatabaseManager.useMockDatabase()
-        scenario.onActivity { MockAuthenticator(it).signIn() }
+        scenario.onActivity { MockAuthenticator(it).signIn().join() }
         assertTrue(DatabaseManager.user != null)
 
         Intents.intended(IntentMatchers.hasComponent(MainActivity::class.java.name))
@@ -111,10 +111,9 @@ class AccountFragmentsTest {
             .perform(click())
 
         assertTrue(DatabaseManager.user == null)
-        DatabaseManager.db.getUserById("0").thenAccept {
-            assertTrue(it == null)
-            checkGuest()
-        }
+        val user = DatabaseManager.db.getUserById("0").join()
+        assertTrue(user == null)
+        checkGuest()
     }
 
     private fun checkGuest() {

--- a/app/src/androidTest/java/com/github/ybecker/epforuml/account/AccountFragmentsTest.kt
+++ b/app/src/androidTest/java/com/github/ybecker/epforuml/account/AccountFragmentsTest.kt
@@ -82,6 +82,8 @@ class AccountFragmentsTest {
         scenario.onActivity { MockAuthenticator(it).signIn().join() }
         assertTrue(DatabaseManager.user != null)
 
+        Thread.sleep(2000)
+
         Intents.intended(IntentMatchers.hasComponent(MainActivity::class.java.name))
 
         onView(ViewMatchers.withContentDescription(R.string.open))
@@ -100,6 +102,8 @@ class AccountFragmentsTest {
         DatabaseManager.useMockDatabase()
         scenario.onActivity { MockAuthenticator(it).signIn().join() }
         assertTrue(DatabaseManager.user != null)
+
+        Thread.sleep(2000)
 
         Intents.intended(IntentMatchers.hasComponent(MainActivity::class.java.name))
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -81,7 +81,7 @@
             android:exported="false" />
         <activity
             android:name=".sensor.CameraActivity"
-            android:exported="false"></activity>
+            android:exported="false" />
         <activity
             android:name=".sensor.EditPhotoActivity"
             android:exported="true">

--- a/app/src/main/java/com/github/ybecker/epforuml/HomeFragment.kt
+++ b/app/src/main/java/com/github/ybecker/epforuml/HomeFragment.kt
@@ -12,6 +12,9 @@ import com.github.ybecker.epforuml.database.DatabaseManager.db
 import com.github.ybecker.epforuml.database.Model.*
 import android.widget.ImageButton
 import androidx.core.content.ContextCompat
+import androidx.core.os.bundleOf
+import androidx.fragment.app.add
+import androidx.fragment.app.commit
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
 import com.github.ybecker.epforuml.database.DatabaseManager
 import java.util.concurrent.CompletableFuture
@@ -23,7 +26,7 @@ import java.util.concurrent.CompletableFuture
  *
  * Hosts the RecyclerView displaying all questions
  */
-class HomeFragment(private val mainActivity: MainActivity) : Fragment() {
+class HomeFragment : Fragment() {
 
     /**
      * The questions adapter
@@ -43,6 +46,9 @@ class HomeFragment(private val mainActivity: MainActivity) : Fragment() {
      * The temporary (to be completed) list of questions
      */
     private lateinit var futureCourseList: CompletableFuture<List<Course>>
+
+    private lateinit var mainActivity: MainActivity
+
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
@@ -53,11 +59,13 @@ class HomeFragment(private val mainActivity: MainActivity) : Fragment() {
         //DatabaseManager.useMockDatabase()
         futureCourseList = db.availableCourses()
 
+        mainActivity = activity as MainActivity
+
         val newQuestionButton = view.findViewById<ImageButton>(R.id.new_question_button)
         // Set click listener for the circular button with the "+" sign
         newQuestionButton.setOnClickListener {
             // Navigate to the new fragment to add a new question
-            mainActivity.replaceFragment(NewQuestionFragment(mainActivity))
+            mainActivity.replaceFragment(NewQuestionFragment())
         }
 
         return view

--- a/app/src/main/java/com/github/ybecker/epforuml/MainActivity.kt
+++ b/app/src/main/java/com/github/ybecker/epforuml/MainActivity.kt
@@ -5,8 +5,11 @@ import android.os.Bundle
 import android.view.MenuItem
 import androidx.appcompat.app.ActionBarDrawerToggle
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.os.bundleOf
 import androidx.drawerlayout.widget.DrawerLayout
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.add
+import androidx.fragment.app.commit
 import com.github.ybecker.epforuml.notifications.FirebaseCouldMessagingAdapter
 import com.github.ybecker.epforuml.account.AccountFragment
 import com.github.ybecker.epforuml.account.AccountFragmentGuest
@@ -42,11 +45,11 @@ class MainActivity : AppCompatActivity() {
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
 
         if(savedInstanceState == null) {
-            supportFragmentManager.beginTransaction().replace(R.id.frame_layout, HomeFragment(this)).commit()
+            supportFragmentManager.beginTransaction().replace(R.id.frame_layout, HomeFragment()).commit()
         }
 
         if( intent.extras?.getString("fragment").equals("NewQuestionFragment")) {
-            supportFragmentManager.beginTransaction().replace(R.id.frame_layout, NewQuestionFragment(this)).commit()
+            supportFragmentManager.beginTransaction().replace(R.id.frame_layout, NewQuestionFragment()).commit()
         }
         if( intent.extras?.getString("fragment").equals("RealChat")) {
             supportFragmentManager.beginTransaction().replace(R.id.frame_layout, RealChatFragment()).commit()
@@ -54,10 +57,12 @@ class MainActivity : AppCompatActivity() {
         if( intent.extras?.getString("fragment").equals("chatHome")) {
             supportFragmentManager.beginTransaction().replace(R.id.frame_layout, ChatHomeFragment()).commit()
         }
+        // Remove it otherwise we might jump back to this fragment later
+        intent.removeExtra("fragment")
 
         navView.setNavigationItemSelectedListener {
             when(it.itemId) {
-                R.id.nav_home -> replaceFragment(HomeFragment(this))
+                R.id.nav_home -> replaceFragment(HomeFragment())
                 R.id.nav_courses -> replaceFragment(CoursesFragment())
                 R.id.nav_my_questions -> replaceFragment(MyQuestionsFragment())
                 R.id.nav_saved_questions -> replaceFragment(SavedQuestionsFragment())

--- a/app/src/main/java/com/github/ybecker/epforuml/MainActivity.kt
+++ b/app/src/main/java/com/github/ybecker/epforuml/MainActivity.kt
@@ -60,7 +60,7 @@ class MainActivity : AppCompatActivity() {
         }
 
         if(fragment.equals("NewQuestionFragment")) {
-            replaceFragment(NewQuestionFragment(this))
+            replaceFragment(NewQuestionFragment())
         }
         if(fragment.equals("RealChat")) {
             replaceFragment(RealChatFragment())

--- a/app/src/main/java/com/github/ybecker/epforuml/NewQuestionFragment.kt
+++ b/app/src/main/java/com/github/ybecker/epforuml/NewQuestionFragment.kt
@@ -8,7 +8,10 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.*
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.core.os.bundleOf
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.add
+import androidx.fragment.app.commit
 import com.github.ybecker.epforuml.database.DatabaseManager
 import com.github.ybecker.epforuml.database.DatabaseManager.db
 import com.github.ybecker.epforuml.database.Model
@@ -19,7 +22,7 @@ import com.github.ybecker.epforuml.sensor.CameraActivity
  * Use the [NewQuestionFragment.newInstance] factory method to
  * create an instance of this fragment.
  */
-class NewQuestionFragment(val mainActivity: MainActivity) : Fragment() {
+class NewQuestionFragment : Fragment() {
 
     private lateinit var questBody : EditText
     private lateinit var questTitle : EditText
@@ -31,6 +34,8 @@ class NewQuestionFragment(val mainActivity: MainActivity) : Fragment() {
             imageURI.text = uri.toString()
         }
 
+    private lateinit var mainActivity: MainActivity
+
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
@@ -38,6 +43,7 @@ class NewQuestionFragment(val mainActivity: MainActivity) : Fragment() {
         val user = DatabaseManager.user
         val view = inflater.inflate(R.layout.fragment_new_question, container, false)
 
+        mainActivity = activity as MainActivity
 
         val spinner = view.findViewById<Spinner>(R.id.subject_spinner)
         // Get the set of available courses from the MockDatabase
@@ -108,7 +114,7 @@ class NewQuestionFragment(val mainActivity: MainActivity) : Fragment() {
                         questBody.text.toString(),
                         imageURI.toString()
                     )
-                    mainActivity.replaceFragment(HomeFragment(mainActivity))
+                    mainActivity.replaceFragment(HomeFragment())
                 }
             }
         }

--- a/app/src/main/java/com/github/ybecker/epforuml/QuestionDetailsActivity.kt
+++ b/app/src/main/java/com/github/ybecker/epforuml/QuestionDetailsActivity.kt
@@ -33,6 +33,7 @@ class QuestionDetailsActivity : AppCompatActivity() {
         val button : Button = findViewById(R.id.back_to_forum_button)
         button.setOnClickListener{ // Create an intent to return to the previous fragment
             startActivity(Intent(this, MainActivity::class.java))
+            finish()
         }
 
         swipeRefreshLayout = findViewById(R.id.swipe_refresh_layout)

--- a/app/src/main/java/com/github/ybecker/epforuml/authentication/Authenticator.kt
+++ b/app/src/main/java/com/github/ybecker/epforuml/authentication/Authenticator.kt
@@ -5,6 +5,7 @@ import androidx.activity.result.ActivityResultLauncher
 import androidx.appcompat.app.AppCompatActivity
 import com.github.ybecker.epforuml.database.Model
 import com.google.firebase.auth.FirebaseUser
+import java.util.concurrent.CompletableFuture
 
 /**
  * Interface that represents a mean to authenticate
@@ -13,15 +14,15 @@ interface Authenticator {
     /**
      * Allows a user to sign-in
      */
-    fun signIn()
+    fun signIn(): CompletableFuture<Void>
 
     /**
      * Allows the current logged-in user to sign-out
      */
-    fun signOut()
+    fun signOut(): CompletableFuture<Void>
 
     /**
      * Deletes the current logged-in user from the firebase user list and the database
      */
-    fun deleteUser()
+    fun deleteUser(): CompletableFuture<Void>
 }

--- a/app/src/main/java/com/github/ybecker/epforuml/authentication/FirebaseAuthenticator.kt
+++ b/app/src/main/java/com/github/ybecker/epforuml/authentication/FirebaseAuthenticator.kt
@@ -139,14 +139,11 @@ class FirebaseAuthenticator(
                         firebaseUser.displayName!!,
                         firebaseUser.email!!
                     ).thenAccept { newUser ->
-                        DatabaseManager.user = newUser
+                        gotToActivity(newUser)
                     }
                 } else {
-                    DatabaseManager.user = user
+                    gotToActivity(user)
                 }
-                DatabaseManager.db.setUserPresence(DatabaseManager.user!!.userId)
-                DatabaseManager.user!!.connections.add(true)
-                gotToActivity(DatabaseManager.user!!.username)
             }
         }
     }
@@ -154,10 +151,14 @@ class FirebaseAuthenticator(
     /**
      * Shows sign-in Toast and goes to MainActivity or AccountFragment
      */
-    private fun gotToActivity(username: String) {
+    private fun gotToActivity(newUser: Model.User) {
+        DatabaseManager.user = newUser
+        DatabaseManager.db.setUserPresence(DatabaseManager.user!!.userId)
+        DatabaseManager.user!!.connections.add(true)
+
         Toast.makeText(
             activity,
-            "Successfully signed in as $username",
+            "Successfully signed in as ${newUser.username}",
             Toast.LENGTH_LONG
         ).show()
 

--- a/app/src/main/java/com/github/ybecker/epforuml/authentication/LoginActivity.kt
+++ b/app/src/main/java/com/github/ybecker/epforuml/authentication/LoginActivity.kt
@@ -29,9 +29,15 @@ class LoginActivity : AppCompatActivity() {
         val authenticator = FirebaseAuthenticator(this)
 
         val signInButton = findViewById<Button>(R.id.signInButton)
-        signInButton.setOnClickListener { authenticator.signIn() }
-
         val guestButton = findViewById<Button>(R.id.guestButton)
+        signInButton.setOnClickListener {
+            signInButton.isEnabled = false
+            guestButton.isEnabled = false
+            authenticator.signIn().thenAccept {
+                signInButton.isEnabled = true
+                guestButton.isEnabled = true
+            }
+        }
         guestButton.setOnClickListener { continueAsGuest() }
 
         checkIfAlreadySignedIn()

--- a/app/src/main/java/com/github/ybecker/epforuml/authentication/MockAuthenticator.kt
+++ b/app/src/main/java/com/github/ybecker/epforuml/authentication/MockAuthenticator.kt
@@ -29,21 +29,18 @@ class MockAuthenticator(private val activity: AppCompatActivity) : Authenticator
     }
 
     override fun signOut(): CompletableFuture<Void> {
-        signOutResult = CompletableFuture()
-        val user = DatabaseManager.user
-        if (user != null) {
-            DatabaseManager.db.removeUserConnection(user.userId)
-            DatabaseManager.user = null
-            signOutResult.complete(null)
-        }
-        return signOutResult
+        return signOutOrDelete { DatabaseManager.db.removeUserConnection(it) }
     }
 
     override fun deleteUser(): CompletableFuture<Void> {
+        return signOutOrDelete { DatabaseManager.db.removeUser(it) }
+    }
+
+    private fun signOutOrDelete(execute: (userId: String) -> Unit): CompletableFuture<Void> {
         signOutResult = CompletableFuture()
         val user = DatabaseManager.user
         if (user != null) {
-            DatabaseManager.db.removeUser(user.userId)
+            execute(user.userId)
             DatabaseManager.user = null
             signOutResult.complete(null)
         }

--- a/app/src/main/java/com/github/ybecker/epforuml/chat/SearchActivity.kt
+++ b/app/src/main/java/com/github/ybecker/epforuml/chat/SearchActivity.kt
@@ -33,6 +33,7 @@ class SearchActivity : AppCompatActivity() {
             val intent = Intent(this, MainActivity::class.java)
             intent.putExtra("fragment", "chatHome")
             startActivity(intent)
+            finish()
         }
 
         db.registeredUsers().thenAccept { listIt ->


### PR DESCRIPTION
Hello, I managed to fix the following issues :
- Sign-in not signing-in at first try
- Dark mode and phone changing orientation making the app crash or swap to another activity
- Add a future return for authentication methods to be able to wait for the authentication to finish before going further